### PR TITLE
Disregard return value from `create_directory`

### DIFF
--- a/lib/mix/tasks/plug_rest.gen.resource.ex
+++ b/lib/mix/tasks/plug_rest.gen.resource.ex
@@ -87,7 +87,7 @@ defmodule Mix.Tasks.PlugRest.Gen.Resource do
           Mix.raise "The --path option must name a directory or .ex file"
       end
 
-    :ok = file |> Path.dirname() |> create_directory()
+    file |> Path.dirname() |> create_directory()
 
     namespace = Keyword.get(opts, :namespace, app_mod)
     resource_module = Enum.join([namespace, resource], ".")


### PR DESCRIPTION
Since Elixir 1.9.0, `Mix.Generator.create_directory` returns `true` and
not `:ok`.

This change ensures compatibility with Elixir 1.9.x.
The return value is always `true`, so there is no need to match on it.